### PR TITLE
feat: Replace .crystal TLD with .local. Automate Caddy certs

### DIFF
--- a/components/furnituremix/Makefile
+++ b/components/furnituremix/Makefile
@@ -11,7 +11,6 @@ DOCKER_COMPOSE := $(DOCKER_COMPOSE_ARGS) docker compose
 NPM := npm
 CADDY = caddy
 CADDY_PID_FILE := provisioning/dev/caddy.dev.pid
-MKCERT = mkcert
 
 .DEFAULT_GOAL := list
 
@@ -28,15 +27,10 @@ clean: stop ## Clean non-essential files
 	@$(DOCKER_COMPOSE) down
 	
 .PHONY: install
-install: install-certificates ## Install
+install:
 	@$(NPM) install
 	@cd application && cp .env.dist .env && cd ..
 	@cd application && $(NPM) install && cd ..	
-	
-.PHONY: install-certificates
-install-certificates: ## Install the certificates
-	@$(MKCERT) -install
-	@cd provisioning/dev/certs && $(MKCERT) --cert-file domains.pem -key-file key.pem "*.superfast.crystal"
 
 .PHONY: npmupdate
 npmupdate: ## npmupdate

--- a/components/furnituremix/README.md
+++ b/components/furnituremix/README.md
@@ -12,7 +12,6 @@ If you want to report or contribute, you should do it on the main repository: ht
 
 -   Volta.sh (that will bring good version of Node )
 -   Caddy Server v2
--   `mkcert` for https with local domains
 
 # Installation
 
@@ -22,8 +21,20 @@ For a better experience and respect the [Twelve-Facter App](https://12factor.net
 
 Add an entry for the subdomains in your `/etc/hosts` file:
 
+### Using /etc/hosts
+
 ```
-127.0.0.1 SUPERFASTPROJECTIDENTIFIER.superfast.crystal
+127.0.0.1 SUPERFASTPROJECTIDENTIFIER.superfast.local
+```
+
+### Using dnsmasq for multiple tenants
+
+You only ever need to do this once for all Superfast stores you might set up
+
+```
+brew install dnsmasq
+echo "address=/superfast.local/127.0.0.1" >> /opt/homebrew/etc/dnsmasq.conf
+sudo brew services restart dnsmasq
 ```
 
 ## Installation
@@ -36,8 +47,6 @@ make install
 
 This will:
 
--   install the Certificate Authority using `mkcert`
--   generate the certificates `mkcert` for `*.superfast.crystal`
 -   `npm install` the `frontend` folder
 
 ## Run the project
@@ -54,7 +63,7 @@ This will:
 
 > you can stop non stopped services with `make stop`
 
--   Frontend: https://furniture.superfast.crystal
+-   Frontend: https://furniture.superfast.local
 -   Mailcatcher - Web: http://localhost:3022
 -   Mailcatcher SMTP: http://localhost:3021
 -   Redis: tcp://localhost:3023

--- a/components/furnituremix/provisioning/dev/Caddyfile
+++ b/components/furnituremix/provisioning/dev/Caddyfile
@@ -1,5 +1,11 @@
-*.superfast.crystal {
-    tls ./provisioning/dev/certs/domains.pem ./provisioning/dev/certs/key.pem
+{
+    local_certs
+}
+
+*.superfast.local {
+    tls {
+        on_demand
+    }
     push
     @websockets {
         header Connection *Upgrade*


### PR DESCRIPTION
Shave off a step with cert setup for Caddy by automating it while also moving to .local domain.
Added instructions for how to use dnsmasq instead of /etc/hosts to setup superfast mDNS once and for all