### PR TITLE
[SERVICE-API] Fixing bug: updating stripe order model so that customer details can be accessed 

### DIFF
--- a/components/service-api/src/services/payment-providers/stripe/to-crystallize-order-model.js
+++ b/components/service-api/src/services/payment-providers/stripe/to-crystallize-order-model.js
@@ -7,11 +7,12 @@ module.exports = async function stripeToCrystallizeOrderModel({
   const { getClient } = require("./utils");
 
   const paymentIntent = await getClient().paymentIntents.retrieve(
-    paymentIntentId
+    paymentIntentId, {
+    expand: ['latest_charge']
+    }
   );
 
-  const { data } = paymentIntent.charges;
-  const charge = data[0];
+  const charge = paymentIntent.latest_charge;
 
   const customerName = charge.billing_details.name.split(" ");
   let email = charge.receipt_email;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Fixed tickets | #... 

I have been messing around with your boiler plates and had an error from the service API once I connected stripe and tried to do a test checkout.

The current code is trying to access the 'charges' object with paymentIntent.charges;

I changed this to 'latest_charge' and to access this I had to also expand on this object (as per Stripe documentation) with the line above - stripe client.retrieve().

Doing so in my own project seemed to fix the problem so I thought I would also add a PR for the boilerplate
